### PR TITLE
release: v0.56.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,15 @@ LABEL "maintainer"="peaceiris"
 ENV HUGO_VERSION='0.56.3'
 ENV HUGO_NAME="hugo_extended_${HUGO_VERSION}_Linux-64bit"
 ENV HUGO_URL="https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${HUGO_NAME}.tar.gz"
+ENV MUFFET_VERSION="1.1.2"
+ENV MUFFET_NAME="muffet_1.1.2_Linux_x86_64"
+ENV MUFFET_URL="https://github.com/raviqqe/muffet/releases/download/${MUFFET_VERSION}/${MUFFET_NAME}.tar.gz"
 RUN wget "${HUGO_URL}" && \
     tar -zxvf "${HUGO_NAME}.tar.gz" && \
     mv ./hugo /go/bin/ && \
-    go get -u github.com/raviqqe/muffet
+    wget "${MUFFET_URL}" && \
+    tar -zxvf "${MUFFET_NAME}.tar.gz" && \
+    mv ./muffet /go/bin/
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]


### PR DESCRIPTION
- [x] change: install muffet from binary (Fixes #1)
- [ ] upgrade: hugo v0.56.3
- [ ] update: tag on readme
- [ ] release